### PR TITLE
fix(sync): increase sync max concurrent reconciles

### DIFF
--- a/internal/controller/sync_controller.go
+++ b/internal/controller/sync_controller.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	juicefsiov1 "github.com/juicedata/juicefs-operator/api/v1"
@@ -364,6 +365,10 @@ func (r *SyncReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&juicefsiov1.Sync{}).
 		Owns(&corev1.Pod{}).
+		WithOptions(controller.Options{
+			// TODO: configable
+			MaxConcurrentReconciles: 5,
+		}).
 		Named("sync").
 		Complete(r)
 }


### PR DESCRIPTION
- bump max sync concurrent reconciler to 5

avoid blocking new sync tasks due to a stuck task (usually create worker pod failed)