### PR TITLE
fix(sync): delete complete worker pod when progressing & add more concurrent options

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,7 +25,6 @@ linters:
     - errcheck
     - ginkgolinter
     - goconst
-    - gocyclo
     - gofmt
     - goimports
     - gosimple

--- a/cmd/app/controller.go
+++ b/cmd/app/controller.go
@@ -25,6 +25,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/juicedata/juicefs-operator/internal/controller"
+	"github.com/juicedata/juicefs-operator/pkg/common"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -48,6 +50,7 @@ func init() {
 	fs := flag.NewFlagSet("", flag.ExitOnError)
 	zapOpts.BindFlags(fs)
 	ControllerCmd.Flags().AddGoFlagSet(fs)
+	ControllerCmd.PersistentFlags().IntVarP(&common.MaxSyncConcurrentReconciles, "max-sync-concurrent-reconciles", "", 10, "max concurrent reconciles for sync")
 }
 
 func run() {

--- a/cmd/app/controller.go
+++ b/cmd/app/controller.go
@@ -51,6 +51,8 @@ func init() {
 	zapOpts.BindFlags(fs)
 	ControllerCmd.Flags().AddGoFlagSet(fs)
 	ControllerCmd.PersistentFlags().IntVarP(&common.MaxSyncConcurrentReconciles, "max-sync-concurrent-reconciles", "", 10, "max concurrent reconciles for sync")
+	ControllerCmd.PersistentFlags().Float32VarP(&common.K8sClientQPS, "k8s-client-qps", "", 30, "QPS indicates the maximum QPS to the master from this client. Setting this to a negative value will disable client-side ratelimiting")
+	ControllerCmd.PersistentFlags().IntVarP(&common.K8sClientBurst, "k8s-client-burst", "", 20, "Maximum burst for throttle")
 }
 
 func run() {

--- a/cmd/app/manager.go
+++ b/cmd/app/manager.go
@@ -19,6 +19,7 @@ package app
 import (
 	"crypto/tls"
 
+	"github.com/juicedata/juicefs-operator/pkg/common"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -68,7 +69,11 @@ func NewManager() (ctrl.Manager, error) {
 		// https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.19.0/pkg/metrics/filters#WithAuthenticationAndAuthorization
 		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
 	}
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+
+	cfg := ctrl.GetConfigOrDie()
+	cfg.QPS = common.K8sClientQPS
+	cfg.Burst = common.K8sClientBurst
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
 		HealthProbeBindAddress: probeAddr,

--- a/internal/controller/sync_controller.go
+++ b/internal/controller/sync_controller.go
@@ -193,7 +193,7 @@ func (r *SyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		status, err := r.calculateSyncStats(ctx, sync, managerPod)
 		if !reflect.DeepEqual(sync.Status, status) {
 			sync.Status = status
-			if err := utils.IgnoreConflict(r.Status().Update(ctx, sync)); err != nil {
+			if err := r.Status().Update(ctx, sync); err != nil {
 				return ctrl.Result{}, err
 			}
 		}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -92,6 +92,9 @@ var (
 	DefaultWaitingMaxDuration   = 1 * time.Hour
 
 	MaxSyncConcurrentReconciles = 10
+
+	K8sClientQPS   float32 = 30
+	K8sClientBurst int     = 20
 )
 
 func GenWorkerName(cgName string, nodeName string) string {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -90,6 +90,8 @@ var (
 
 	DefaultBackupWorkerDuration = 10 * time.Minute
 	DefaultWaitingMaxDuration   = 1 * time.Hour
+
+	MaxSyncConcurrentReconciles = 10
 )
 
 func GenWorkerName(cgName string, nodeName string) string {


### PR DESCRIPTION
- Delete the completed worker pod as soon as possible to avoid too many completed pods triggering [kubelet limits](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/).

<img width="784" alt="image" src="https://github.com/user-attachments/assets/6a47ba79-ebf6-4153-85a6-c148ffac1469" />

- add more concurrent options
- add more log