### PR TITLE
fix(sync):List pod is not accurate

### DIFF
--- a/internal/controller/sync_controller.go
+++ b/internal/controller/sync_controller.go
@@ -349,6 +349,7 @@ func (r *SyncReconciler) prepareWorkerPod(ctx context.Context, sync *juicefsiov1
 		case <-ctx.Done():
 			return fmt.Errorf("timeout waiting for worker pod ready")
 		default:
+			pods = &corev1.PodList{}
 			err := r.List(ctx, pods, labelSelector)
 			if err != nil {
 				log.Error(err, "failed to list worker pods")


### PR DESCRIPTION


## 问题描述
在ctrl.NewManager 的时候 同时在ctrl.Options 中设置NewCache 方法开启cache
prepareWorkerPod 在等待worker pod ready 的循环中会每次追加pods 变量，导致检查worker pod 状态超时 失败

## 修复方式
每次list pod 之前重置pods 变量


