### PR TITLE
fix(warmup): cronbjob compatible

### DIFF
--- a/cmd/app/manager.go
+++ b/cmd/app/manager.go
@@ -88,9 +88,6 @@ func NewManager() (ctrl.Manager, error) {
 			&corev1.Pod{}: {
 				Label: labels.SelectorFromSet(labels.Set{common.LabelManagedBy: common.LabelManagedByValue}),
 			},
-			&batchv1.CronJob{}: {
-				Label: labels.SelectorFromSet(labels.Set{common.LabelManagedBy: common.LabelManagedByValue}),
-			},
 			&batchv1.Job{}: {
 				Label: labels.SelectorFromSet(labels.Set{common.LabelManagedBy: common.LabelManagedByValue}),
 			},

--- a/internal/controller/warmup_controller.go
+++ b/internal/controller/warmup_controller.go
@@ -43,7 +43,7 @@ import (
 type WarmUpReconciler struct {
 	client.Client
 	Scheme           *runtime.Scheme
-	CronjobSupported bool
+	cronjobSupported bool
 }
 
 // +kubebuilder:rbac:groups=juicefs.io,resources=warmups,verbs=get;list;watch;create;update;patch;delete
@@ -120,7 +120,7 @@ func (r *WarmUpReconciler) getWarmUpHandler(policyType juicefsiov1.PolicyType) w
 	case juicefsiov1.PolicyTypeOnce:
 		return &onceHandler{r.Client}
 	case juicefsiov1.PolicyTypeCron:
-		if !r.CronjobSupported {
+		if !r.cronjobSupported {
 			return nil
 		}
 		return &cronHandler{r.Client}
@@ -335,7 +335,7 @@ func (r *WarmUpReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	if isCronJobAPIAvailable(mgr) {
 		controllerBuilder = controllerBuilder.Owns(&batchv1.CronJob{})
-		r.CronjobSupported = true
+		r.cronjobSupported = true
 	} else {
 		log.Log.Info("CronJob API is not available in this Kubernetes cluster, scheduled warmup functionality will be disabled. Only manual warmup jobs will be supported.")
 	}

--- a/internal/controller/warmup_controller.go
+++ b/internal/controller/warmup_controller.go
@@ -322,12 +322,26 @@ func (r *WarmUpReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
 		For(&juicefsiov1.WarmUp{}).
 		Owns(&batchv1.Job{}).
-		Owns(&batchv1.CronJob{}).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: common.MaxWarmupConcurrentReconciles,
-		}).
-		Complete(r)
+		})
+
+	if isCronJobAPIAvailable(mgr) {
+		controllerBuilder = controllerBuilder.Owns(&batchv1.CronJob{})
+	} else {
+		log.Log.Info("CronJob API is not available in this Kubernetes cluster, scheduled warmup functionality will be disabled. Only manual warmup jobs will be supported.")
+	}
+
+	return controllerBuilder.Complete(r)
+}
+
+// isCronJobAPIAvailable checks if the CronJob API is available in the cluster
+func isCronJobAPIAvailable(mgr ctrl.Manager) bool {
+	mapper := mgr.GetRESTMapper()
+	gvk := batchv1.SchemeGroupVersion.WithKind("CronJob")
+	_, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	return err == nil
 }


### PR DESCRIPTION
If k8s is below 1.20, there is no `batchv1.Cronjob API`, disable the cron feature of warmup