### PR TITLE
fix(cg): adjust scheduling logic

### DIFF
--- a/internal/controller/cachegroup_controller.go
+++ b/internal/controller/cachegroup_controller.go
@@ -427,6 +427,10 @@ func (r *CacheGroupReconciler) removeRedundantWorkers(
 		} else {
 			workerKey = worker.Spec.NodeName
 		}
+		// worker may be waiting for scheduler dispatch, waiting for next reconciler
+		if workerKey == "" && cg.Spec.EnableScheduling {
+			continue
+		}
 		if _, ok := expectStates[workerKey]; ok {
 			continue
 		}


### PR DESCRIPTION
- When the `enableScheduling` is true, worker pod may be in a pending phase (with an empty node name field) waiting for scheduling, which can be identified as redundant workers and deleted.